### PR TITLE
ci: automate build version bump on merged PRs

### DIFF
--- a/.github/workflows/bump-build-version.yml
+++ b/.github/workflows/bump-build-version.yml
@@ -1,0 +1,45 @@
+name: Bump build version
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bump-build-version-main
+  cancel-in-progress: false
+
+jobs:
+  bump-build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch/build version
+        run: |
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          IFS='.' read -r MAJOR MINOR BUILD <<< "$CURRENT_VERSION"
+          NEXT_BUILD=$((BUILD + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_BUILD}"
+
+          npm version "$NEXT_VERSION" --no-git-tag-version
+
+          git add package.json package-lock.json
+          git commit -m "chore(release): bump build version to v${NEXT_VERSION}" || exit 0
+
+      - name: Push version bump
+        run: git push

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm run test:ui       # Run tests in interactive mode
 ### CI/CD
 - All commits to `main` trigger automated Playwright tests via GitHub Actions
 - Branch protection requires passing tests before merge
+- Each merged PR to `main` auto-increments the build version (`x.x.[build]`) in `package.json` and `package-lock.json`
+- Deployed footer metadata always uses the current package version plus build timestamp and commit SHA
 - Tests verify:
   - Grid rendering (4x4 and 9x9)
   - Input validation


### PR DESCRIPTION
## Summary
- add a workflow that runs when a PR is merged into `main`
- increment the build component of `package.json`/`package-lock.json` from `x.x.[build]` to the next build number
- document the version bump behavior in `README.md`

## Why
Closes #10 by making build version updates deterministic and automatic after each merged PR.

## Notes
- Uses `npm version --no-git-tag-version` to keep lockfile/version in sync
- Commits with `github-actions[bot]` and pushes directly to `main` from workflow
